### PR TITLE
Improve embed support

### DIFF
--- a/webapp/js/components/ViewDataset.vue
+++ b/webapp/js/components/ViewDataset.vue
@@ -1,20 +1,9 @@
 <template>
 <div id="browser" class="cui app">
     <Message bindTo="error" />
-    <Map v-if="$view === 'map'" :files="fileBrowserFiles" @scrollTo="handleScrollTo" />
-    <Potree v-else-if="$view === '3d'" :files="fileBrowserFiles" />
-    <Explorer v-else-if="$view === 'files'" ref="explorer"
-                    :files="fileBrowserFiles"
-                    :tools="explorerTools"
-                    :currentPath="currentPath"
-                    @openItem="handleOpenItem"
-                    @deleteSelecteditems="openDeleteItemsDialog"
-                    @moveSelectedItems="openRenameItemsDialog"
-                    @moveItem="handleMoveItem"
-                    @openProperties="handleExplorerOpenProperties" />
-    <Panel split="vertical" class="container main" amount="23.6%" mobileAmount="0%" tabletAmount="30%" mobileCollapsed v-show="$view === null">
-        <div class="sidebar">
-            <FileBrowser v-if="!isMobile" :rootNodes="rootNodes"
+    <Panel split="vertical" class="container main" amount="23.6%" mobileAmount="0%" tabletAmount="30%" mobileCollapsed>
+        <div class="sidebar" v-show="!$only" >
+            <FileBrowser v-show="!isMobile" :rootNodes="rootNodes"
                 @openItem="handleOpenItem"
                 @selectionChanged="handleFileSelectionChanged"
                 @currentUriChanged="handleCurrentUriChanged"
@@ -23,8 +12,7 @@
                 @moveSelectedItems="openRenameItemsDialogFromFileBrowser"
                 @error="handleError" />
         </div>
-
-        <TabSwitcher :tabs="mainTabs"
+        <TabSwitcher :tabs="mainTabs" :selectedTab="startTab"
                 position="top"
                 buttonWidth="auto"
                 :hideSingle="true"
@@ -46,7 +34,7 @@
                 <Potree :files="fileBrowserFiles" />
             </template>
             <template v-slot:explorer>
-                <Explorer ref="explorer"
+                <Explorer ref="explorer" 
                     :files="fileBrowserFiles"
                     :tools="explorerTools"
                     :currentPath="currentPath"
@@ -57,8 +45,8 @@
                     @openProperties="handleExplorerOpenProperties" />
             </template>
         </TabSwitcher>
-        <Properties v-if="showProperties" :files="contextMenuFiles" @onClose="handleCloseProperties" />
     </Panel>
+    <Properties v-if="showProperties" :files="contextMenuFiles" @onClose="handleCloseProperties" />
     <SettingsDialog v-if="showSettings" :dataset="dataset" @onClose="handleSettingsClose" @addMarkdown="handleAddMarkdown" />
     <AddToDatasetDialog v-if="uploadDialogOpen" @onClose="handleAddClose" :path="currentPath" :organization="dataset.org" :dataset="dataset.ds" :filesToUpload="filesToUpload" :open="true"></AddToDatasetDialog>
     <DeleteDialog v-if="deleteDialogOpen" @onClose="handleDeleteClose" :files="contextMenuFiles"></DeleteDialog>
@@ -123,33 +111,76 @@ export default {
     data: function () {
         const mobile = isMobile();
 
-        let mainTabs = [{
-            label: 'Map',
-            icon: 'map',
-            key: 'map'
-        }];
-        if (mobile){
-            mainTabs.unshift({
-                label: 'Browser',
-                icon: 'sitemap',
-                key: 'filebrowser'
-            });
-        }
-        if (window.WebGL2RenderingContext){
-            mainTabs.push({
-                label: '3D',
-                icon: 'cube',
-                key: 'potree'
-            });
-        }
+        var mainTabs = [];
+        var startTab = null;
 
-        mainTabs = mainTabs.concat([{
+        if (!this.$only || this.$view == null) {
+
+            mainTabs.push({
+                label: 'Map',
+                icon: 'map',
+                key: 'map'
+            });
+
+            if (mobile){
+                mainTabs.unshift({
+                    label: 'Browser',
+                    icon: 'sitemap',
+                    key: 'filebrowser'
+                });
+            }
+            if (window.WebGL2RenderingContext){
+                mainTabs.push({
+                    label: '3D',
+                    icon: 'cube',
+                    key: 'potree'
+                });
+            }
+
+            mainTabs = mainTabs.concat([{
                 label: 'Files',
                 icon: 'folder open',
                 key: 'explorer'
             }]);
 
+            startTab = this.$view;
+
+        } else {
+            switch(this.$view) {
+                case 'map':
+
+                    mainTabs.push({
+                        label: 'Map',
+                        icon: 'map',
+                        key: 'map'
+                    });
+
+                    break;
+
+                case 'explorer':
+
+                    mainTabs.push({
+                        label: 'Files',
+                        icon: 'folder open',
+                        key: 'explorer'
+                    });
+
+                    break;
+
+                case 'potree':
+
+                    mainTabs.push({
+                        label: '3D',
+                        icon: 'cube',
+                        key: 'potree'
+                    });
+
+                    break;
+            }
+        }
+
         return {
+            startTab: startTab,
             error: "",
             isMobile: mobile,
             mainTabs: mainTabs,
@@ -580,7 +611,8 @@ export default {
             deep: true,
             handler: function (newVal, oldVal) {
                 const $header = this.$parent.$children[0];
-                $header.selectedFiles = this.selectedFiles;
+                if (!this.$embed)
+                    $header.selectedFiles = this.selectedFiles;
             }
         },
 

--- a/webapp/js/components/ViewDataset.vue
+++ b/webapp/js/components/ViewDataset.vue
@@ -1,8 +1,18 @@
 <template>
 <div id="browser" class="cui app">
     <Message bindTo="error" />
-
-    <Panel split="vertical" class="container main" amount="23.6%" mobileAmount="0%" tabletAmount="30%" mobileCollapsed>
+    <Map v-if="$view === 'map'" :files="fileBrowserFiles" @scrollTo="handleScrollTo" />
+    <Potree v-else-if="$view === '3d'" :files="fileBrowserFiles" />
+    <Explorer v-else-if="$view === 'files'" ref="explorer"
+                    :files="fileBrowserFiles"
+                    :tools="explorerTools"
+                    :currentPath="currentPath"
+                    @openItem="handleOpenItem"
+                    @deleteSelecteditems="openDeleteItemsDialog"
+                    @moveSelectedItems="openRenameItemsDialog"
+                    @moveItem="handleMoveItem"
+                    @openProperties="handleExplorerOpenProperties" />
+    <Panel split="vertical" class="container main" amount="23.6%" mobileAmount="0%" tabletAmount="30%" mobileCollapsed v-show="$view === null">
         <div class="sidebar">
             <FileBrowser v-if="!isMobile" :rootNodes="rootNodes"
                 @openItem="handleOpenItem"
@@ -47,7 +57,6 @@
                     @openProperties="handleExplorerOpenProperties" />
             </template>
         </TabSwitcher>
-
         <Properties v-if="showProperties" :files="contextMenuFiles" @onClose="handleCloseProperties" />
     </Panel>
     <SettingsDialog v-if="showSettings" :dataset="dataset" @onClose="handleSettingsClose" @addMarkdown="handleAddMarkdown" />
@@ -57,8 +66,7 @@
     <NewFolderDialog v-if="createFolderDialogOpen" @onClose="handleNewFolderClose"></NewFolderDialog>
     <Alert :title="errorMessageTitle" v-if="errorDialogOpen" @onClose="handleErrorDialogClose">
         {{errorMessage}}
-    </Alert>
-
+    </Alert>    
     <Loader v-if="isBusy"></Loader>
 </div>
 </template>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -36,7 +36,10 @@ window.addEventListener('load', function(){
     const embed = !!params.embed || inIframe();
     if (embed) hdr = null;
 
-    Vue.prototype.$view = params.view ? params.view : null;
+    var allowedViews = ['explorer', 'potree', 'map', null];
+    Vue.prototype.$view = allowedViews.includes(params.view) ? params.view : null;
+    Vue.prototype.$embed = params.embed ? true : false;
+    Vue.prototype.$only = params.only ? true : false;
 
     Vue.use(VueLogger, options);
     Vue.use(VueRouter);

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -30,9 +30,13 @@ window.addEventListener('load', function(){
 
     let hdr = Header;
 
+    var params = queryParams(window.location);
+
     // Hide header if ?embed=1 is in URL
-    const embed = !!queryParams(window.location).embed || inIframe();
+    const embed = !!params.embed || inIframe();
     if (embed) hdr = null;
+
+    Vue.prototype.$view = params.view ? params.view : null;
 
     Vue.use(VueLogger, options);
     Vue.use(VueRouter);


### PR DESCRIPTION
Closes #46 

Parameters: 

- `embed`: hide header
- `view`: preselected view, allowed values: `map`, `potree` (3d view) and `explorer` (files)
- `only`: show only what is specified in `view` parameter (`embed` value is ignored)

Example:

```
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=explorer&only=1" style="width: 500px; height: 400px"></iframe>
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=potree&only=1" style="width: 500px; height: 400px"></iframe>
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=map&only=1" style="width: 500px; height: 400px"></iframe>    
<br />
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=explorer" style="width: 800px; height: 400px"></iframe>
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=potree" style="width: 800px; height: 400px"></iframe>
    <iframe src="https://localhost:5001/r/admin/brighton?embed=1&view=map" style="width: 800px; height: 400px"></iframe>    
```

Support PR https://github.com/DroneDB/CommonUI/pull/15