### PR TITLE
Orgs/ds management simplification

### DIFF
--- a/webapp/js/components/AddToDatasetDialog.vue
+++ b/webapp/js/components/AddToDatasetDialog.vue
@@ -10,11 +10,6 @@
                             @done="done"
                             :open="open"
                             :filesToUpload="filesToUpload"></DatasetUpload>
-            <div class="buttons">
-                <button @click="close" class="ui button">
-                    Close
-                </button>
-            </div>
         </div>
     </Window>
 </template>

--- a/webapp/js/components/DatasetUpload.vue
+++ b/webapp/js/components/DatasetUpload.vue
@@ -255,6 +255,7 @@ export default {
     height: 100%;
 }
 .uploading{
+    width: 100%;
     text-align: center;
     .circle.notch{
         margin-bottom: 12px;

--- a/webapp/js/components/Upload.vue
+++ b/webapp/js/components/Upload.vue
@@ -277,6 +277,7 @@ export default {
     height: 100%;
 }
 .uploading{
+    width: 100%;
     text-align: center;
     .circle.notch{
         margin-bottom: 12px;

--- a/webapp/js/components/datasets/Datasets.vue
+++ b/webapp/js/components/datasets/Datasets.vue
@@ -4,8 +4,7 @@
 
     <div class="top-banner ui equal width grid middle aligned">
         <div class="column">
-            <h1>{{ $route.params.org }}</h1>
-            <p>Datasets are the DroneDB databases that belong to this organization.</p>
+            <h1>{{ orgName }}</h1>
         </div>
         <div class="column right aligned">
             <button @click.stop="handleNew()" class="ui primary button icon"><i class="ui icon add"></i>&nbsp;Create Dataset</button>
@@ -18,11 +17,10 @@
         <div v-for="ds in datasets" class="ui segments datasets">
             <div class="ui segment" @click="viewDataset(ds)">
                 <div class="ui grid middle aligned flex-container">
-                    <div class="flex-item column left aligned main-col"><i class="large database icon"></i>{{ds.slug}}</div>
-                    <div class="flex-item column left aligned">{{ds.name ? ds.name : '—'}}</div>
+                    <div class="flex-item column left aligned main-col"><i class="large database icon"></i>{{ds.name ? ds.name : ds.slug}}</div>
                     <div class="flex-item column left aligned">
-                        <span v-if="ds.entries == 0">—</span>
-                        <div v-else><div style="margin-bottom: 5px">{{ds.entries}} <span v-if="ds.entries > 1">files</span><span v-else>file</span></div><div>{{bytesToSize(ds.size)}}</div></div>
+                        <span v-if="ds.entries == 0">0 files</span>
+                        <div v-else><div style="margin-bottom: 5px">{{ds.entries}} <span v-if="ds.entries > 1">files</span><span v-else>file</span></div> <div>{{bytesToSize(ds.size)}}</div></div>
                     </div>
                     <div class="flex-item column left aligned">
                         <div v-if="ds.public"><i class="large globe icon"></i>Public</div>
@@ -90,19 +88,24 @@ export default {
 
             dsDialogModel: null,
             dsDialogMode: null,
-            dsDialogOpen: false        
+            dsDialogOpen: false,
+
+            orgName: this.$route.params.org     
         }
     },
     mounted: async function(){
-        setTitle(this.$route.params.org);
         
         try {
-
+            
             this.org = reg.Organization(this.$route.params.org);
+            const orgInfo = await this.org.info();
+
+            this.orgName = orgInfo.name !== "" ? orgInfo.name : this.$route.params.org;
+            setTitle(this.orgName);
+            
             const tmp = await this.org.datasets();
 
             this.datasets = tmp.map(ds => {
-                console.log(ds);
                 return {
                     slug: ds.slug,
                     creationDate: Date.parse(ds.creationDate),                    
@@ -306,10 +309,8 @@ export default {
 
 <style scoped>
 #datasets {
-
     .top-banner {
-        margin-top: 30px;
-        margin-bottom: 40px;
+        margin-bottom: 12px;
     }
 
     margin: 12px;

--- a/webapp/js/components/organizations/OrganizationDialog.vue
+++ b/webapp/js/components/organizations/OrganizationDialog.vue
@@ -3,48 +3,45 @@
             modal
             maxWidth="70%"
             fixedSize>
-
-        <form class="ui form">
-            <div class="fields" v-if="mode == 'new'">
-                <div class="field">
-                    <label>Slug</label>
-                    <input type="text" pattern="[a-z0-9_]+" required v-model="org.slug" @keydown="filterKeys($event)" placeholder="Slug" />
+        <div class="org-dialog">
+            <form class="ui form">
+                <div class="fields" v-if="mode == 'new'">
+                    <div class="field">
+                        <label>Name</label>
+                        <input type="text" v-model="org.name" placeholder="Name" />
+                    </div>
                 </div>
-                <div class="field">
+                <div class="field" v-else>
                     <label>Name</label>
                     <input type="text" v-model="org.name" placeholder="Name" />
                 </div>
+                <div class="field">
+                    <label>Description</label>
+                    <textarea v-model="org.description" placeholder="Description"></textarea>
+                </div>
+                <div class="inline field">
+                    <label>Public</label>
+                    <input type="checkbox" v-model="org.isPublic" />
+                </div>
+            </form>        
+            <div class="buttons">
+                <button @click="close('close')" class="ui button">
+                    Close
+                </button>
+                <button v-if="mode == 'new'" @click="close('create')" class="ui button primary" :disabled="!isValid()">
+                    Create
+                </button>
+                <button v-else @click="close('save')" class="ui button primary" :disabled="!isValid()">
+                    Save
+                </button>
             </div>
-            <div class="field" v-else>
-                <label>Name</label>
-                <input type="text" v-model="org.name" placeholder="Name" />
-            </div>
-            <div class="field">
-                <label>Description</label>
-                <textarea v-model="org.description" placeholder="Description"></textarea>
-            </div>
-            <div class="inline field">
-                <label>Public</label>
-                <input type="checkbox" v-model="org.isPublic" />
-            </div>
-        </form>        
-        <div class="buttons">
-            <button @click="close('close')" class="ui button">
-                Close
-            </button>
-            <button v-if="mode == 'new'" @click="close('create', org)" class="ui button primary" :disabled="!isValid()">
-                Create
-            </button>
-            <button v-else @click="close('save', org)" class="ui button primary" :disabled="!isValid()">
-                Save
-            </button>
         </div>
     </Window>
 </template>
 
 <script>
 import Window from '../Window.vue';
-
+import { slugFromName } from '../../libs/registryUtils';
 
 var re = /^[a-z0-9\-_]+$/;
 
@@ -58,7 +55,6 @@ export default {
     data: function(){
         return {
             org: {
-                slug: null,
                 name: null,
                 description: null,
                 isPublic: false
@@ -70,17 +66,15 @@ export default {
 
         if (this.mode == 'edit') {
 
-            this.title = "Edit organization " + this.model.slug;
+            this.title = "Edit " + this.model.slug;
 
-            this.org.slug = this.model.slug;
             this.org.name = this.model.name;
             this.org.description = this.model.description;
             this.org.isPublic = this.model.isPublic;
         } else {
 
-            this.title = "Create new organization";
+            this.title = "Add New Organization";
 
-            this.org.slug = null;
             this.org.name = null;
             this.org.description = null;
             this.org.isPublic = false;
@@ -101,26 +95,37 @@ export default {
             }
         },
         close: function(buttonId, obj){
-            this.$emit('onClose', buttonId, obj);
+            this.$emit('onClose', buttonId, {
+                name: this.org.name,
+                description: typeof this.org.description === "string" ? this.org.description : "",
+                isPublic: this.org.isPublic,
+                slug: slugFromName(this.org.name)
+            });
         },
         isValid: function(){
-
-
             // organization slug can contain only letters, numbers, dashes and underscores
-
-            return this.org.slug && re.test(this.org.slug) && this.org.name;
+            const slug = slugFromName(this.org.name);
+            return slug && re.test(slug) && this.org.name;
         }
     }
 }
 </script>
 
 <style scoped>
+.org-dialog{
+    min-width: 320px;
+    padding: 4px;
+}
 .buttons{
     margin-top: 16px;
     text-align: right;
 }
 .form {
     margin-bottom: 20px;
+}
+
+.field{
+    width: 100%;
 }
 
 .fields .field:first-child {

--- a/webapp/js/components/organizations/Organizations.vue
+++ b/webapp/js/components/organizations/Organizations.vue
@@ -5,10 +5,9 @@
     <div class="top-banner ui equal width grid middle aligned">
         <div class="column">
             <h1>Organizations</h1>
-            <p>Organizations are groups of datasets managed by a single owner.</p>
         </div>
         <div class="column right aligned">
-            <button @click.stop="handleNew()" class="ui primary button icon"><i class="ui icon add"></i>&nbsp;Create Organization</button>
+            <button @click.stop="handleNew()" class="ui primary button icon"><i class="ui icon add"></i> Add New</button>
         </div>
     </div>
     <div v-if="loading" class="loading">
@@ -18,9 +17,7 @@
         <div v-for="org in organizations" class="ui segments organization">            
             <div class="ui segment" @click="viewOrganization(org)">
                 <div class="ui grid middle aligned flex-container">
-                    <div class="flex-item column left aligned main-col"><i class="large users icon"></i>{{org.slug}}</div>
-                    <div class="flex-item column left aligned">{{org.name ? org.name : '—'}}</div>
-                    <div class="flex-item column left aligned">{{org.owner ? org.owner : '—'}}</div>
+                    <div class="flex-item column left aligned main-col"><i class="large users icon"></i>{{org.name ? org.name : org.slug}}</div>
                     <div class="flex-item column left aligned">
                         <div v-if="org.isPublic"><i class="large globe icon"></i>Public</div>
                         <div v-else><i class="large lock icon"></i>Private</div>
@@ -274,8 +271,7 @@ export default {
 <style scoped>
 #organizations {
     .top-banner {
-        margin-top: 30px;
-        margin-bottom: 40px;
+        margin-bottom: 12px;
     }
     margin: 12px;
     margin-top: 16px;

--- a/webapp/js/libs/registryUtils.js
+++ b/webapp/js/libs/registryUtils.js
@@ -6,11 +6,7 @@ export async function renameDataset(orgSlug, dsSlug, name){
 
     if (name.length > 128) name = name.slice(0, 128);
 
-    let slug = name.toLowerCase();
-    slug = slug.replace(/ /g, "-");
-    slug = slug.replace(/[^a-z0-9_-]/g, "");
-    while(slug.startsWith("_") || slug.startsWith("-")) slug = slug.slice(1);
-
+    let slug = slugFromName(name);
     await ds.metaSet("name", name);
     return await ds.rename(slug);
 };
@@ -19,3 +15,12 @@ export function datasetName(ds){
     return ds.properties.meta?.name?.data || ds.slug;
 }
 
+export function slugFromName(name){
+    if (!name) return null;
+
+    let slug = name.toLowerCase();
+    slug = slug.replace(/ /g, "-");
+    slug = slug.replace(/[^a-z0-9_-]/g, "");
+    while(slug.startsWith("_") || slug.startsWith("-")) slug = slug.slice(1);
+    return slug;
+}


### PR DESCRIPTION
Simplifies the organization/dataset UI by removing the need to type the slug field.

Users do not understand (neither should they care) what a "slug" is, and it's not their job to pick proper URLs.

In time (if needed) we can add an "Advanced" mode where the slug can be independently set, but for the time being, it shouldn't be a user-set parameter.


